### PR TITLE
Remove child model associated type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ N/A
 
 ### Removed
 
-N/A
+- The associated type `ChildModel` on `EagerLoadChildrenOfType` has been removed because it wasn't necessary.
 
 ### Fixed
 

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
@@ -79,8 +79,6 @@ pub struct HasOneInner {
     #[darling(default)]
     foreign_key_field: Option<syn::Ident>,
     #[darling(default)]
-    model: Option<syn::Path>,
-    #[darling(default)]
     root_model_field: Option<syn::Ident>,
     #[darling(default)]
     graphql_field: Option<syn::Ident>,
@@ -100,8 +98,6 @@ pub struct HasManyInner {
 
     #[darling(default)]
     foreign_key_field: Option<syn::Ident>,
-    #[darling(default)]
-    model: Option<syn::Path>,
     #[darling(default)]
     root_model_field: Option<syn::Ident>,
     #[darling(default)]
@@ -123,8 +119,6 @@ pub struct HasManyThroughInner {
     skip: Option<()>,
 
     #[darling(default)]
-    model: Option<syn::Path>,
-    #[darling(default)]
     join_model: Option<syn::Path>,
     #[darling(default)]
     model_field: Option<syn::Path>,
@@ -139,7 +133,6 @@ pub struct HasManyThroughInner {
 pub struct FieldArgs {
     foreign_key_field: Option<syn::Ident>,
     join_model_field: Option<syn::Path>,
-    model: Option<syn::Path>,
     model_field: Option<syn::Path>,
     pub join_model: Option<syn::Path>,
     pub skip: bool,
@@ -150,14 +143,6 @@ pub struct FieldArgs {
 }
 
 impl FieldArgs {
-    pub fn model(&self, inner_type: &syn::Type) -> TokenStream {
-        if let Some(inner) = &self.model {
-            quote! { #inner }
-        } else {
-            quote! { models::#inner_type }
-        }
-    }
-
     pub fn foreign_key_field(&self, field_name: &Ident) -> TokenStream {
         if let Some(inner) = &self.foreign_key_field {
             quote! { #inner }
@@ -236,7 +221,6 @@ impl From<HasOneInner> for FieldArgs {
     fn from(inner: HasOneInner) -> Self {
         Self {
             foreign_key_field: inner.foreign_key_field,
-            model: inner.model,
             root_model_field: inner.root_model_field,
             join_model: None,
             model_field: None,
@@ -257,7 +241,6 @@ impl From<HasManyInner> for FieldArgs {
 
         Self {
             foreign_key_field: inner.foreign_key_field,
-            model: inner.model,
             root_model_field: inner.root_model_field,
             join_model: None,
             model_field: None,
@@ -278,7 +261,6 @@ impl From<HasManyThroughInner> for FieldArgs {
 
         Self {
             foreign_key_field: None,
-            model: inner.model,
             root_model_field: None,
             join_model: inner.join_model,
             model_field: inner.model_field,

--- a/juniper-eager-loading/examples/has_many.rs
+++ b/juniper-eager-loading/examples/has_many.rs
@@ -125,7 +125,6 @@ pub struct User {
 
     #[has_many(
         root_model_field = "car",
-        model = "models::Car",
         foreign_key_field = "user_id",
         graphql_field = "cars",
         predicate_method = "a_predicate_method"

--- a/juniper-eager-loading/examples/has_many_through.rs
+++ b/juniper-eager-loading/examples/has_many_through.rs
@@ -163,7 +163,6 @@ pub struct User {
 
     #[has_many_through(
         join_model = "models::Employment",
-        model = "models::Company",
         model_field = "company",
         join_model_field = "employment",
         predicate_method = "a_predicate_method",

--- a/juniper-eager-loading/examples/has_one.rs
+++ b/juniper-eager-loading/examples/has_one.rs
@@ -92,7 +92,6 @@ pub struct User {
     // these are the defaults. `#[has_one(default)]` would also work here.
     #[has_one(
         foreign_key_field = "country_id",
-        model = "models::Country",
         root_model_field = "country",
         graphql_field = "country"
     )]

--- a/juniper-eager-loading/examples/option_has_one.rs
+++ b/juniper-eager-loading/examples/option_has_one.rs
@@ -92,7 +92,6 @@ pub struct User {
     // these are the defaults. `#[option_has_one(default)]` would also work here.
     #[option_has_one(
         foreign_key_field = "country_id",
-        model = "models::Country",
         root_model_field = "country",
         graphql_field = "country"
     )]

--- a/juniper-eager-loading/tests/integration_tests.rs
+++ b/juniper-eager-loading/tests/integration_tests.rs
@@ -297,14 +297,12 @@ pub struct User {
 
     // #[has_one(
     //     foreign_key_field = "country_id",
-    //     model = "models::Country",
     //     root_model_field = "country"
     // )]
     #[has_one(default)]
     country: HasOne<Country>,
 
     // #[has_one(
-    //     model = "models::City",
     //     foreign_key_field = "city_id",
     //     root_model_field = "city"
     // )]
@@ -315,7 +313,6 @@ pub struct User {
     employments: HasMany<Employment>,
 
     #[has_many_through(
-        // model = "models::Company",
         // model_field = "company",
         // join_model_field = "employment"
         join_model = "models::Employment",
@@ -452,11 +449,7 @@ impl CountryFields for Country {
 )]
 pub struct City {
     city: models::City,
-    #[has_one(
-        foreign_key_field = "country_id",
-        model = "models::Country",
-        root_model_field = "country"
-    )]
+    #[has_one(foreign_key_field = "country_id", root_model_field = "country")]
     country: HasOne<Country>,
 }
 


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-eager-loading/issues/4

This is a breaking change so has to be shipped in 0.2.0. Probably makes sense to also include a fix for https://github.com/davidpdrsn/juniper-eager-loading/issues/3 in the same release since that is also breaking.