### PR TITLE
Implement `foreign_key_optional` for `HasMany`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
-N/A
+* Support for optional foreign keys when using `HasMany` by using the `foreign_key_optional` attiribute.
 
 ### Changed
 

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading.rs
@@ -211,6 +211,7 @@ impl DeriveData {
             model_field: args.model_field(&inner_type),
             join_model_field: args.join_model_field(),
             foreign_key_field: args.foreign_key_field(foreign_key_field_default),
+            foreign_key_optional: args.foreign_key_optional,
             field_root_model_field: args.root_model_field(&field_name),
             association_type,
             predicate_method: args.predicate_method(),
@@ -411,9 +412,16 @@ impl DeriveData {
                 }
             }
             AssociationType::HasMany => {
-                quote! {
-                      node.#root_model_field.id ==
-                          (child.0).#field_root_model_field.#foreign_key_field
+                if data.foreign_key_optional {
+                    quote! {
+                        Some(node.#root_model_field.id) ==
+                            (child.0).#field_root_model_field.#foreign_key_field
+                    }
+                } else {
+                    quote! {
+                        node.#root_model_field.id ==
+                            (child.0).#field_root_model_field.#foreign_key_field
+                    }
                 }
             }
             AssociationType::HasManyThrough => {
@@ -665,6 +673,7 @@ fn parse_field_args<T: FromMeta>(field: &syn::Field) -> Result<T, darling::Error
 #[allow(dead_code)]
 struct FieldDeriveData {
     foreign_key_field: TokenStream,
+    foreign_key_optional: bool,
     field_root_model_field: TokenStream,
     root_model_field: TokenStream,
     join_model: TokenStream,

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
@@ -101,6 +101,8 @@ pub struct HasManyInner {
     #[darling(default)]
     foreign_key_field: Option<syn::Ident>,
     #[darling(default)]
+    foreign_key_optional: Option<()>,
+    #[darling(default)]
     model: Option<syn::Path>,
     #[darling(default)]
     root_model_field: Option<syn::Ident>,
@@ -138,6 +140,7 @@ pub struct HasManyThroughInner {
 
 pub struct FieldArgs {
     foreign_key_field: Option<syn::Ident>,
+    pub foreign_key_optional: bool,
     join_model_field: Option<syn::Path>,
     model: Option<syn::Path>,
     model_field: Option<syn::Path>,
@@ -236,6 +239,7 @@ impl From<HasOneInner> for FieldArgs {
     fn from(inner: HasOneInner) -> Self {
         Self {
             foreign_key_field: inner.foreign_key_field,
+            foreign_key_optional: false,
             model: inner.model,
             root_model_field: inner.root_model_field,
             join_model: None,
@@ -257,6 +261,7 @@ impl From<HasManyInner> for FieldArgs {
 
         Self {
             foreign_key_field: inner.foreign_key_field,
+            foreign_key_optional: inner.foreign_key_optional.is_some(),
             model: inner.model,
             root_model_field: inner.root_model_field,
             join_model: None,
@@ -278,6 +283,7 @@ impl From<HasManyThroughInner> for FieldArgs {
 
         Self {
             foreign_key_field: None,
+            foreign_key_optional: false,
             model: inner.model,
             root_model_field: None,
             join_model: inner.join_model,

--- a/juniper-eager-loading/src/lib.rs
+++ b/juniper-eager-loading/src/lib.rs
@@ -670,6 +670,7 @@ impl<T> OptionHasOne<T> {
 /// | Name | Description | Default | Example |
 /// |---|---|---|---|
 /// | `foreign_key_field` | The name of the foreign key field | `{name of struct}_id` | `foreign_key_field = "user_id"` |
+/// | `foreign_key_optional` | The foreign key type is optional | Not set | `foreign_key_optional` |
 /// | `model` | The database model type | `models::{name of contained type}` | `model = "models::Car"` |
 /// | `root_model_field` | The name of the field on the associated GraphQL type that holds the database model | N/A (unless using `skip`) | `root_model_field = "car"` |
 /// | `graphql_field` | The name of this field in your GraphQL schema | `{name of field}` | `graphql_field = "country"` |


### PR DESCRIPTION
This PR adds a new attribute to `#[has_many]` that enables support for
HasMany relations where the child foreign key is optional.

This PR is mainly plumbing for getting the attribute through to
`child_ids_impl` and then a small bit for using the value to decide
whether to wrap the parent id in `Some(..)`.

Fixes #7 