### PR TITLE
Fix spelling mistake in eager_load_all_children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ N/A
 
 ### Fixed
 
-N/A
+* Fixed spelling mistake in `eager_load_all_children` (from `eager_load_all_chilren`).
 
 ## [0.1.1]
 

--- a/juniper-eager-loading/src/lib.rs
+++ b/juniper-eager-loading/src/lib.rs
@@ -1232,7 +1232,7 @@ where
     /// Perform eager loading for list of GraphQL values.
     ///
     /// This is the function you should call for eager loading associations of a single value.
-    fn eager_load_all_chilren(
+    fn eager_load_all_children(
         node: Self,
         models: &[Self::Model],
         db: &Self::Connection,


### PR DESCRIPTION
It was spelt 'eager_load_all_chilren' before.

This also adds an integration test for fetching a single graphql value
('user'), which makes use of the fixed function.