### PR TITLE
Allow/fix use of mixed id types between parent and child.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ N/A
 
 ### Fixed
 
-N/A
+* Previously, using mixed ID types between parent and child types would not compile. This now actually works.
 
 ## [0.1.1]
 

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading.rs
@@ -351,6 +351,10 @@ impl DeriveData {
 
     fn load_children_impl(&self, data: &FieldDeriveData) -> TokenStream {
         let normalize_ids = self.normalize_ids(data);
+        let inner_type = &data.inner_type;
+        let child_id_type = quote! {
+            <#inner_type as juniper_eager_loading::GraphqlNodeForModel>::Id
+        };
 
         quote! {
             fn load_children(
@@ -361,7 +365,7 @@ impl DeriveData {
                 <
                     Self::ChildModel
                     as
-                    juniper_eager_loading::LoadFrom<Self::Id>
+                    juniper_eager_loading::LoadFrom<#child_id_type>
                 >::load(&ids, db)
             }
         }
@@ -443,18 +447,23 @@ impl DeriveData {
     }
 
     fn child_id(&self, data: &FieldDeriveData) -> TokenStream {
+        let inner_type = &data.inner_type;
+        let child_id_type = quote! {
+            <#inner_type as juniper_eager_loading::GraphqlNodeForModel>::Id
+        };
+
         match data.association_type {
             AssociationType::HasOne => {
-                quote! { Self::Id }
+                quote! { #child_id_type }
             }
             AssociationType::OptionHasOne => {
-                quote! { Option<Self::Id> }
+                quote! { Option<#child_id_type> }
             }
             AssociationType::HasMany => {
-                quote! { Vec<Self::Id> }
+                quote! { Vec<#child_id_type> }
             }
             AssociationType::HasManyThrough => {
-                quote! { Vec<Self::Id> }
+                quote! { Vec<#child_id_type> }
             }
         }
     }

--- a/juniper-eager-loading/src/lib.rs
+++ b/juniper-eager-loading/src/lib.rs
@@ -1061,7 +1061,6 @@ where
             Model = Self::ChildModel,
             Connection = Self::Connection,
             Error = Self::Error,
-            Id = Self::Id,
         > + EagerLoadAllChildren<QueryTrailT>
         + Clone,
     QueryTrailT: GenericQueryTrail<Child, Walked>,

--- a/juniper-eager-loading/tests/integration_tests.rs
+++ b/juniper-eager-loading/tests/integration_tests.rs
@@ -373,7 +373,7 @@ pub struct User {
     #[has_many(
         root_model_field = "issue",
         foreign_key_field = "reviewer_id",
-        foreign_key_optional,
+        foreign_key_optional
     )]
     issues: HasMany<Issue>,
 
@@ -589,9 +589,7 @@ impl EmploymentFields for Employment {
 #[eager_loading(connection = "Db", error = "Box<dyn std::error::Error>")]
 pub struct Issue {
     issue: models::Issue,
-    #[option_has_one(
-        root_model_field = "user"
-    )]
+    #[option_has_one(root_model_field = "user")]
     reviewer: OptionHasOne<User>,
 }
 

--- a/juniper-eager-loading/tests/mixed_id_types.rs
+++ b/juniper-eager-loading/tests/mixed_id_types.rs
@@ -1,0 +1,311 @@
+use assert_json_diff::{assert_json_eq, assert_json_include};
+use juniper::{Executor, FieldResult, ID, EmptyMutation};
+use juniper_eager_loading::{
+    prelude::*, EagerLoading, HasMany, HasManyThrough, HasOne, OptionHasOne,
+};
+use juniper_from_schema::graphql_schema;
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{borrow::Borrow, collections::HashMap, hash::Hash};
+
+graphql_schema! {
+    schema {
+      query: Query
+    }
+
+    type Query {
+      users: [User!]! @juniper(ownership: "owned")
+    }
+
+    type User {
+        id: Int!
+        country: Country!
+    }
+
+    type Country {
+        id: ID! @juniper(ownership: "owned")
+    }
+}
+
+mod models {
+    #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+    pub struct User {
+        pub id: i32,
+        pub country_id: i64,
+    }
+
+    #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+    pub struct Country {
+        pub id: i64,
+    }
+
+    impl juniper_eager_loading::LoadFrom<i32> for User {
+        type Error = Box<dyn std::error::Error>;
+        type Connection = super::Db;
+
+        fn load(ids: &[i32], db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+            let models = db
+                .users
+                .all_values()
+                .into_iter()
+                .filter(|value| ids.contains(&value.id))
+                .cloned()
+                .collect::<Vec<_>>();
+            Ok(models)
+        }
+    }
+
+    impl juniper_eager_loading::LoadFrom<i64> for Country {
+        type Error = Box<dyn std::error::Error>;
+        type Connection = super::Db;
+
+        fn load(ids: &[i64], db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+            let countries = db
+                .countries
+                .all_values()
+                .into_iter()
+                .filter(|value| ids.contains(&value.id))
+                .cloned()
+                .collect::<Vec<_>>();
+            Ok(countries)
+        }
+    }
+}
+
+pub struct Db {
+    users: StatsHash<i32, models::User>,
+    countries: StatsHash<i64, models::Country>,
+}
+
+pub struct Context {
+    db: Db,
+}
+
+impl juniper::Context for Context {}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_users<'a>(
+        &self,
+        executor: &Executor<'a, Context>,
+        trail: &QueryTrail<'a, User, Walked>,
+    ) -> FieldResult<Vec<User>> {
+        let db = &executor.context().db;
+
+        let mut user_models = db
+            .users
+            .all_values()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        user_models.sort_by_key(|user| user.id);
+
+        let mut users = User::from_db_models(&user_models);
+        User::eager_load_all_children_for_each(&mut users, &user_models, db, trail)?;
+
+        Ok(users)
+    }
+}
+
+// The default values are commented out
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, EagerLoading)]
+#[eager_loading(
+    connection = "Db",
+    error = "Box<dyn std::error::Error>",
+)]
+pub struct User {
+    user: models::User,
+
+    #[has_one(default)]
+    country: HasOne<Country>,
+}
+
+impl UserFields for User {
+    fn field_id(&self, _executor: &Executor<'_, Context>) -> FieldResult<&i32> {
+        Ok(&self.user.id)
+    }
+
+    fn field_country(
+        &self,
+        _executor: &Executor<'_, Context>,
+        _trail: &QueryTrail<'_, Country, Walked>,
+    ) -> FieldResult<&Country> {
+        Ok(self.country.try_unwrap()?)
+    }
+}
+
+// #[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EagerLoading)]
+#[eager_loading(
+    model = "models::Country",
+    connection = "Db",
+    id = "i64",
+    error = "Box<dyn std::error::Error>",
+    root_model_field = "country"
+)]
+pub struct Country {
+    country: models::Country,
+}
+
+impl CountryFields for Country {
+    fn field_id(&self, _executor: &Executor<'_, Context>) -> FieldResult<ID> {
+        Ok(self.country.id.to_string().into())
+    }
+}
+
+#[test]
+fn loading_users_and_associations() {
+    let mut countries = StatsHash::new("countries");
+    let mut users = StatsHash::new("users");
+
+    let country = models::Country { id: 10 };
+
+    countries.insert(country.id, country.clone());
+
+    users.insert(
+        1,
+        models::User {
+            id: 1,
+            country_id: country.id,
+        },
+    );
+
+    let db = Db {
+        users,
+        countries,
+    };
+
+    let (json, counts) = run_query(
+        r#"
+        query Test {
+            users {
+                id
+                country {
+                    id
+                }
+            }
+        }
+    "#,
+        db,
+    );
+
+    assert_json_include!(
+        expected: json!({
+            "users": [
+                {
+                    "id": 1,
+                    "country": {
+                        "id": country.id.to_string(),
+                    },
+                },
+            ]
+        }),
+        actual: json.clone(),
+    );
+
+    assert_eq!(1, counts.user_reads);
+    assert_eq!(1, counts.country_reads);
+}
+
+
+struct DbStats {
+    user_reads: usize,
+    country_reads: usize,
+}
+
+fn run_query(query: &str, db: Db) -> (Value, DbStats) {
+    let ctx = Context { db };
+
+    let (result, errors) = juniper::execute(
+        query,
+        None,
+        &Schema::new(Query, EmptyMutation::new()),
+        &juniper::Variables::new(),
+        &ctx,
+    )
+    .unwrap();
+
+    if !errors.is_empty() {
+        panic!(
+            "GraphQL errors\n{}",
+            serde_json::to_string_pretty(&errors).unwrap()
+        );
+    }
+
+    let json: Value = serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+
+    println!("{}", serde_json::to_string_pretty(&json).unwrap());
+
+    (
+        json,
+        DbStats {
+            user_reads: ctx.db.users.reads_count(),
+            country_reads: ctx.db.countries.reads_count(),
+        },
+    )
+}
+
+struct StatsHash<K: Hash + Eq, V> {
+    map: HashMap<K, V>,
+    count: AtomicUsize,
+    name: &'static str,
+}
+
+impl<K: Hash + Eq, V> StatsHash<K, V> {
+    fn new(name: &'static str) -> Self {
+        StatsHash {
+            map: HashMap::default(),
+            count: AtomicUsize::default(),
+            name,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn get<Q>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.increment_reads_count();
+        self.map.get(k)
+    }
+
+    #[allow(dead_code)]
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.increment_reads_count();
+        self.map.get_mut(k)
+    }
+
+    fn all_values(&self) -> Vec<&V> {
+        self.increment_reads_count();
+        self.map.iter().map(|(_, v)| v).collect()
+    }
+
+    fn reads_count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+
+    fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.map.insert(k, v)
+    }
+
+    fn increment_reads_count(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+trait SortedExtension {
+    fn sorted(self) -> Self;
+}
+
+impl<T: std::cmp::Ord> SortedExtension for Vec<T> {
+    fn sorted(mut self) -> Self {
+        self.sort();
+        self
+    }
+}

--- a/juniper-eager-loading/tests/mixed_id_types.rs
+++ b/juniper-eager-loading/tests/mixed_id_types.rs
@@ -1,5 +1,5 @@
 use assert_json_diff::{assert_json_eq, assert_json_include};
-use juniper::{Executor, FieldResult, ID, EmptyMutation};
+use juniper::{EmptyMutation, Executor, FieldResult, ID};
 use juniper_eager_loading::{
     prelude::*, EagerLoading, HasMany, HasManyThrough, HasOne, OptionHasOne,
 };
@@ -110,10 +110,7 @@ impl QueryFields for Query {
 
 // The default values are commented out
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, EagerLoading)]
-#[eager_loading(
-    connection = "Db",
-    error = "Box<dyn std::error::Error>",
-)]
+#[eager_loading(connection = "Db", error = "Box<dyn std::error::Error>")]
 pub struct User {
     user: models::User,
 
@@ -171,10 +168,7 @@ fn loading_users_and_associations() {
         },
     );
 
-    let db = Db {
-        users,
-        countries,
-    };
+    let db = Db { users, countries };
 
     let (json, counts) = run_query(
         r#"
@@ -207,7 +201,6 @@ fn loading_users_and_associations() {
     assert_eq!(1, counts.user_reads);
     assert_eq!(1, counts.country_reads);
 }
-
 
 struct DbStats {
     user_reads: usize,


### PR DESCRIPTION
So I had several cases in our work project where we use different ID types between different tables in a database (i32 vs i64 typically). Attempting to make this work would result in compiles failing due to mismatched types.

The issue appears to be a few assumptions made in the code base, that can be easily fixed:
* `EagerLoadChildrenOfType` required the `Id` associated type of `GraphqlNodeForModel` for the `Child` type to be equal to that of the parent. This is unnecessary.
* The `EagerLoading` derive used `Self:Id` as the id type for the child as well, which was fixed by getting the correct child id via `GraphqlNodeForModel::Id`.

I added the test as a separate file, to keep it isolated to just the issue it attempt to reproduce.

