### PR TITLE
Allow specifying foreign key for has_many_through.

### DIFF
--- a/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
@@ -133,6 +133,8 @@ pub struct HasManyThroughInner {
     #[darling(default)]
     join_model_field: Option<syn::Path>,
     #[darling(default)]
+    foreign_key_field: Option<syn::Ident>,
+    #[darling(default)]
     predicate_method: Option<syn::Ident>,
     #[darling(default)]
     graphql_field: Option<syn::Ident>,
@@ -282,7 +284,7 @@ impl From<HasManyThroughInner> for FieldArgs {
         }
 
         Self {
-            foreign_key_field: None,
+            foreign_key_field: inner.foreign_key_field,
             foreign_key_optional: false,
             model: inner.model,
             root_model_field: None,

--- a/juniper-eager-loading/src/lib.rs
+++ b/juniper-eager-loading/src/lib.rs
@@ -749,6 +749,7 @@ impl<T> HasMany<T> {
 /// | `model_field` | The field on the contained type that holds the model | `{name of contained type}` in snakecase | `model_field = "company"` |
 /// | `join_model` | The model we have to join with | N/A | `join_model = "models::Employment"` |
 /// | `join_model_field` | The field on the join model type that holds the model | `{name of join model type}` in snakecase | `join_model_field = "employment"` |
+/// | `foreign_key_field` | The field on the join model that contains the parent models id | `{name of parent type in lowercase}_id` | `foreign_key_field = "car_id"` |
 /// | `graphql_field` | The name of this field in your GraphQL schema | `{name of field}` | `graphql_field = "country"` |
 /// | `predicate_method` | Method used to filter child associations. This can be used if you only want to include a subset of the models. This method will be called to filter the join models. | N/A (attribute is optional) | `predicate_method = "a_predicate_method"` |
 ///


### PR DESCRIPTION
Previously the foreign key was always assumed to be `{the name of parent
type}_id` which is not always true.

This commit allows specifying the foreign key to use, just as in
has_many.