### PR TITLE
Simplify EagerLoadChildrenOfType with Association trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 - Move `impl_load_from_for_diesel_{pg|mysql|sqlite}!` to proc-macros. Are fully backwards compatible but will give better errors.
 - Tweak docs for `impl_load_from_for_diesel_{pg|mysql|sqlite}!`.
+- `Association` trait has been added to abstraction over `HasOne`, `OptionHasOne`, `HasMany`, and `HasManyThrough` associations.
 
 ### Breaking changes
 
@@ -18,6 +19,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
     - `LoadResult::Models` has been renamed to `LoadChildrenOutput::ChildAndJoinModels` for the same reason.
     - The second type parameter (used for the join model) now defaults to `()`.
 - The signature of `EagerLoadChildrenOfType::is_child_of` has been changed to `parent: &Self, child: &Child, join_model: &JoinModel`. Manually pulling things out of the tuple was tedious.
+- `EagerLoadChildrenOfType::association` has been added. This methods allows for some boilerplate to be removed from `EagerLoadChildrenOfType`.
+- `EagerLoadChildrenOfType::loaded_child` and `EagerLoadChildrenOfType::assert_loaded_otherwise_failed` has been removed and implemented generically using the new `Association` trait.
 
 If you're using the derive macros for everything in your app you shouldn't have to care about any of these changes. The generated code will automatically handle them.
 

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading.rs
@@ -95,9 +95,8 @@ impl DeriveData {
         let struct_name = self.struct_name();
         let join_model_impl = self.join_model_impl(&data);
         let load_children_impl = self.load_children_impl(&data);
+        let association_impl = self.association_impl(&data);
         let is_child_of_impl = self.is_child_of_impl(&data);
-        let loaded_or_failed_child_impl = self.loaded_or_failed_child_impl(&data);
-        let assert_loaded_otherwise_failed_impl = self.assert_loaded_otherwise_failed_impl(&data);
 
         let context = self.field_context_name(&field);
 
@@ -112,8 +111,7 @@ impl DeriveData {
             > for #struct_name {
                 #load_children_impl
                 #is_child_of_impl
-                #loaded_or_failed_child_impl
-                #assert_loaded_otherwise_failed_impl
+                #association_impl
             }
         };
 
@@ -378,23 +376,15 @@ impl DeriveData {
         }
     }
 
-    fn loaded_or_failed_child_impl(&self, data: &FieldDeriveData) -> TokenStream {
+    fn association_impl(&self, data: &FieldDeriveData) -> TokenStream {
         let field_name = &data.field_name;
         let inner_type = &data.inner_type;
 
         quote! {
-            fn loaded_child(node: &mut Self, child: #inner_type) {
-                node.#field_name.loaded(child)
-            }
-        }
-    }
-
-    fn assert_loaded_otherwise_failed_impl(&self, data: &FieldDeriveData) -> TokenStream {
-        let field_name = &data.field_name;
-
-        quote! {
-            fn assert_loaded_otherwise_failed(node: &mut Self) {
-                node.#field_name.assert_loaded_otherwise_failed();
+            fn association(node: &mut Self) ->
+                &mut dyn juniper_eager_loading::Association<#inner_type>
+            {
+                &mut node.#field_name
             }
         }
     }


### PR DESCRIPTION
This removes the `loaded_child` and  `assert_loaded_otherwise_failed` methods of `EagerLoadChildrenOfType` and insteads calls those through a new trait called `Association`. That trait is implemented for each type of association. Will reduce some boilerplate in handwritten implementations.