### PR TITLE
Support recursive types through Box'ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-None.
+- Support recursive types for `HasOne` and `OptionHasOne` associations. You can now use `HasOne<Box<T>>` or `OptionHasOne<Box<T>>` in your GraphQL types. `HasMany` and `HasManyThrough` already support recursive types because they're backed by `Vec`s.
 
 ### Breaking changes
 
@@ -44,6 +44,7 @@ None.
   - Add second generic argument to `LoadFrom` which will be the arguments and accept argument of that type in `LoadFrom::load`.
 
 If you're using the derive macros for everything in your app you shouldn't have to care about any of these changes. The generated code will automatically handle them.
+
 ## [0.3.1] - 2019-10-09
 
 ### Added

--- a/juniper-eager-loading/src/association.rs
+++ b/juniper-eager-loading/src/association.rs
@@ -1,0 +1,107 @@
+use crate::{HasMany, HasManyThrough, HasOne, HasOneInner, OptionHasOne};
+
+/// Methods available for all association types.
+pub trait Association<T> {
+    /// Store the loaded child on the association.
+    fn loaded_child(&mut self, child: T);
+
+    /// The association should have been loaded by now, if not store an error inside the
+    /// association (if applicable for the particular association).
+    fn assert_loaded_otherwise_failed(&mut self);
+}
+
+// --
+// -- impl for HasOne
+// --
+impl<T> Association<T> for HasOne<T> {
+    fn loaded_child(&mut self, child: T) {
+        has_one_loaded_child(self, child)
+    }
+
+    fn assert_loaded_otherwise_failed(&mut self) {
+        has_one_assert_loaded_otherwise_failed(self)
+    }
+}
+
+impl<T> Association<T> for HasOne<Box<T>> {
+    fn loaded_child(&mut self, child: T) {
+        has_one_loaded_child(self, Box::new(child))
+    }
+
+    fn assert_loaded_otherwise_failed(&mut self) {
+        has_one_assert_loaded_otherwise_failed(self)
+    }
+}
+
+fn has_one_loaded_child<T>(association: &mut HasOne<T>, child: T) {
+    std::mem::replace(&mut association.0, HasOneInner::Loaded(child));
+}
+
+fn has_one_assert_loaded_otherwise_failed<T>(association: &mut HasOne<T>) {
+    association.0.assert_loaded_otherwise_failed()
+}
+
+// --
+// -- impl for OptionHasOne
+// --
+impl<T> Association<T> for OptionHasOne<T> {
+    fn loaded_child(&mut self, child: T) {
+        option_has_one_loaded_child(self, Some(child));
+    }
+
+    fn assert_loaded_otherwise_failed(&mut self) {
+        option_has_one_assert_loaded_otherwise_failed(self)
+    }
+}
+
+impl<T> Association<T> for OptionHasOne<Box<T>> {
+    fn loaded_child(&mut self, child: T) {
+        option_has_one_loaded_child(self, Some(Box::new(child)));
+    }
+
+    fn assert_loaded_otherwise_failed(&mut self) {
+        option_has_one_assert_loaded_otherwise_failed(self)
+    }
+}
+
+fn option_has_one_loaded_child<T>(association: &mut OptionHasOne<T>, child: Option<T>) {
+    std::mem::replace(&mut association.0, child);
+}
+
+fn option_has_one_assert_loaded_otherwise_failed<T>(association: &mut OptionHasOne<T>) {
+    match association.0 {
+        Some(_) => {}
+        None => {
+            std::mem::replace(&mut association.0, None);
+        }
+    }
+}
+
+// --
+// -- impl for HasMany
+// --
+impl<T> Association<T> for HasMany<T> {
+    fn loaded_child(&mut self, child: T) {
+        self.0.push(child);
+    }
+
+    fn assert_loaded_otherwise_failed(&mut self) {
+        // cannot fail, defaults to an empty vec
+    }
+}
+
+// --
+// -- impl for HasManyThrough
+// --
+impl<T> Association<T> for HasManyThrough<T> {
+    fn loaded_child(&mut self, child: T) {
+        self.0.push(child);
+    }
+
+    fn assert_loaded_otherwise_failed(&mut self) {
+        // cannot fail, defaults to an empty vec
+    }
+}
+
+// NOTE: We don't have to implement Association for HasMany<Box<T>> or HasManyThrough<Box<T>>
+// because they already have indirection through the inner Vec. So recursive types are supported.

--- a/juniper-eager-loading/tests/recursive_types.rs
+++ b/juniper-eager-loading/tests/recursive_types.rs
@@ -1,0 +1,221 @@
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+mod helpers;
+
+use assert_json_diff::assert_json_include;
+use helpers::StatsHash;
+use juniper::{EmptyMutation, Executor, FieldResult, ID};
+use juniper_eager_loading::{
+    prelude::*, EagerLoading, HasManyThrough, HasOne, LoadChildrenOutput, LoadFrom, OptionHasOne,
+};
+use juniper_from_schema::graphql_schema;
+use serde_json::{json, Value};
+
+graphql_schema! {
+    schema {
+      query: Query
+    }
+
+    type Query {
+      users: [User!]! @juniper(ownership: "owned")
+    }
+
+    type User {
+        id: Int!
+        parent: User!
+        grandParent: User @juniper(ownership: "as_ref")
+    }
+}
+
+mod models {
+    use juniper_eager_loading::LoadFrom;
+
+    #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+    pub struct User {
+        pub id: i32,
+        pub parent_id: i32,
+        pub grand_parent_id: Option<i32>,
+    }
+
+    impl LoadFrom<i32> for User {
+        type Error = Box<dyn std::error::Error>;
+        type Connection = super::Db;
+
+        fn load(ids: &[i32], _: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+            let models = db
+                .users
+                .all_values()
+                .into_iter()
+                .filter(|value| ids.contains(&value.id))
+                .cloned()
+                .collect::<Vec<_>>();
+            Ok(models)
+        }
+    }
+}
+
+pub struct Db {
+    users: StatsHash<i32, models::User>,
+}
+
+pub struct Context {
+    db: Db,
+}
+
+impl juniper::Context for Context {}
+
+pub struct Query;
+
+impl QueryFields for Query {
+    fn field_users<'a>(
+        &self,
+        executor: &Executor<'a, Context>,
+        trail: &QueryTrail<'a, User, Walked>,
+    ) -> FieldResult<Vec<User>> {
+        let db = &executor.context().db;
+
+        let mut user_models = db
+            .users
+            .all_values()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        user_models.sort_by_key(|user| user.id);
+
+        let mut users = User::from_db_models(&user_models);
+        User::eager_load_all_children_for_each(&mut users, &user_models, db, trail)?;
+
+        Ok(users)
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, EagerLoading)]
+#[eager_loading(connection = "Db", error = "Box<dyn std::error::Error>")]
+pub struct User {
+    user: models::User,
+
+    #[has_one(root_model_field = "user")]
+    parent: HasOne<Box<User>>,
+
+    #[option_has_one(root_model_field = "user")]
+    grand_parent: OptionHasOne<Box<User>>,
+}
+
+impl UserFields for User {
+    fn field_id<'a>(&self, _: &Executor<'a, Context>) -> FieldResult<&i32> {
+        Ok(&self.user.id)
+    }
+
+    fn field_parent<'a>(
+        &self,
+        executor: &Executor<'a, Context>,
+        trail: &QueryTrail<'a, User, Walked>,
+    ) -> FieldResult<&User> {
+        Ok(self.parent.try_unwrap()?)
+    }
+
+    fn field_grand_parent<'a>(
+        &self,
+        executor: &Executor<'a, Context>,
+        trail: &QueryTrail<'a, User, Walked>,
+    ) -> FieldResult<Option<&User>> {
+        let grand_parent = self
+            .grand_parent
+            .try_unwrap()?
+            .as_ref()
+            .map(|boxed| &**boxed);
+
+        Ok(grand_parent)
+    }
+}
+
+#[test]
+fn loading_recursive_type() {
+    let mut users = StatsHash::new("users");
+
+    users.insert(
+        1,
+        models::User {
+            id: 1,
+            parent_id: 1,
+            grand_parent_id: Some(1),
+        },
+    );
+
+    let db = Db { users };
+
+    let (json, counts) = run_query(
+        r#"
+        query Test {
+            users {
+                id
+                parent {
+                    id
+                    parent {
+                        id
+                        grandParent {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    "#,
+        db,
+    );
+
+    assert_json_include!(
+        expected: json!({
+            "users": [
+                {
+                    "id": 1,
+                    "parent": {
+                        "id": 1,
+                        "parent": {
+                            "id": 1,
+                            "grandParent": {
+                                "id": 1,
+                            },
+                        },
+                    },
+                },
+            ]
+        }),
+        actual: json.clone(),
+    );
+}
+
+struct DbStats {
+    user_reads: usize,
+}
+
+fn run_query(query: &str, db: Db) -> (Value, DbStats) {
+    let ctx = Context { db };
+
+    let (result, errors) = juniper::execute(
+        query,
+        None,
+        &Schema::new(Query, EmptyMutation::new()),
+        &juniper::Variables::new(),
+        &ctx,
+    )
+    .unwrap();
+
+    if !errors.is_empty() {
+        panic!(
+            "GraphQL errors\n{}",
+            serde_json::to_string_pretty(&errors).unwrap()
+        );
+    }
+
+    let json: Value = serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+
+    println!("{}", serde_json::to_string_pretty(&json).unwrap());
+
+    (
+        json,
+        DbStats {
+            user_reads: ctx.db.users.reads_count(),
+        },
+    )
+}


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-eager-loading/issues/22

`HasOne<Box<T>>` and `OptionHasOne<Box<T>>` are now supported.