### PR TITLE
Replace GraphqlNodeForModel::Connection with (Juniper) Context

### DIFF
--- a/examples/has_one_no_macros.rs
+++ b/examples/has_one_no_macros.rs
@@ -61,17 +61,17 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<i32> for Country {
         type Error = diesel::result::Error;
-        type Connection = PgConnection;
+        type Context = super::Context;
 
         fn load(
             ids: &[i32],
             _field_args: &(),
-            db: &Self::Connection,
+            ctx: &Self::Context,
         ) -> Result<Vec<Self>, Self::Error> {
             use crate::db_schema::countries::dsl::*;
             use diesel::pg::expression::dsl::any;
 
-            countries.filter(id.eq(any(ids))).load::<Country>(db)
+            countries.filter(id.eq(any(ids))).load::<Country>(&ctx.db)
         }
     }
 }
@@ -84,10 +84,10 @@ impl QueryFields for Query {
         executor: &Executor<'_, Context>,
         trail: &QueryTrail<'_, User, Walked>,
     ) -> FieldResult<Vec<User>> {
-        let db = &executor.context().db;
-        let user_models = db_schema::users::table.load::<models::User>(db)?;
+        let ctx = executor.context();
+        let user_models = db_schema::users::table.load::<models::User>(&ctx.db)?;
         let mut users = User::from_db_models(&user_models);
-        User::eager_load_all_children_for_each(&mut users, &user_models, db, trail)?;
+        User::eager_load_all_children_for_each(&mut users, &user_models, ctx, trail)?;
 
         Ok(users)
     }
@@ -133,7 +133,7 @@ impl CountryFields for Country {
 impl GraphqlNodeForModel for User {
     type Model = models::User;
     type Id = i32;
-    type Connection = PgConnection;
+    type Context = Context;
     type Error = diesel::result::Error;
 
     fn new_from_model(model: &Self::Model) -> Self {
@@ -148,7 +148,7 @@ impl EagerLoadAllChildren for User {
     fn eager_load_all_children_for_each(
         nodes: &mut [User],
         models: &[models::User],
-        db: &PgConnection,
+        ctx: &Self::Context,
         trail: &QueryTrail<'_, Self, Walked>,
     ) -> Result<(), Self::Error> {
         if let Some(child_trail) = trail.country().walk() {
@@ -157,7 +157,7 @@ impl EagerLoadAllChildren for User {
             EagerLoadChildrenOfType::<
                 Country,
                 EagerLoadingContextUserForCountry,
-            _>::eager_load_children(nodes, models, db, &child_trail, &field_args)?;
+            _>::eager_load_children(nodes, models, ctx, &child_trail, &field_args)?;
         }
         Ok(())
     }
@@ -171,7 +171,7 @@ impl<'a> EagerLoadChildrenOfType<'a, Country, EagerLoadingContextUserForCountry,
     fn load_children(
         models: &[models::User],
         field_args: &Self::FieldArguments,
-        db: &PgConnection,
+        ctx: &Self::Context,
     ) -> Result<LoadChildrenOutput<models::Country>, diesel::result::Error> {
         let ids = models
             .iter()
@@ -179,7 +179,7 @@ impl<'a> EagerLoadChildrenOfType<'a, Country, EagerLoadingContextUserForCountry,
             .collect::<Vec<_>>();
         let ids = juniper_eager_loading::unique(ids);
 
-        let child_models: Vec<models::Country> = LoadFrom::load(&ids, field_args, db)?;
+        let child_models: Vec<models::Country> = LoadFrom::load(&ids, field_args, ctx)?;
 
         Ok(LoadChildrenOutput::ChildModels(child_models))
     }
@@ -189,6 +189,7 @@ impl<'a> EagerLoadChildrenOfType<'a, Country, EagerLoadingContextUserForCountry,
         child: &Country,
         _join_model: &(),
         _field_args: &Self::FieldArguments,
+        _ctx: &Self::Context,
     ) -> bool {
         node.user.country_id == child.country.id
     }
@@ -201,7 +202,7 @@ impl<'a> EagerLoadChildrenOfType<'a, Country, EagerLoadingContextUserForCountry,
 impl GraphqlNodeForModel for Country {
     type Model = models::Country;
     type Id = i32;
-    type Connection = PgConnection;
+    type Context = Context;
     type Error = diesel::result::Error;
 
     fn new_from_model(model: &Self::Model) -> Self {
@@ -215,7 +216,7 @@ impl EagerLoadAllChildren for Country {
     fn eager_load_all_children_for_each(
         nodes: &mut [Country],
         models: &[models::Country],
-        db: &PgConnection,
+        ctx: &Self::Context,
         trail: &QueryTrail<'_, Country, Walked>,
     ) -> Result<(), diesel::result::Error> {
         Ok(())

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
@@ -20,12 +20,10 @@ pub struct DeriveArgs {
     model: Option<syn::Path>,
     #[darling(default)]
     id: Option<syn::Path>,
-    connection: syn::Path,
+    context: syn::Path,
     error: syn::Path,
     #[darling(default)]
     root_model_field: Option<syn::Ident>,
-    #[darling(default)]
-    context: Option<syn::Path>,
 
     // TODO: Document this new attribute
     #[darling(default)]
@@ -33,7 +31,7 @@ pub struct DeriveArgs {
 }
 
 impl DeriveArgs {
-    token_stream_getter!(connection);
+    token_stream_getter!(context);
     token_stream_getter!(error);
 
     pub fn model(&self, struct_name: &syn::Ident) -> TokenStream {
@@ -59,14 +57,6 @@ impl DeriveArgs {
             let struct_name = struct_name.to_string().to_snake_case();
             let struct_name = Ident::new(&struct_name, Span::call_site());
             quote! { #struct_name }
-        }
-    }
-
-    pub fn context(&self) -> TokenStream {
-        if let Some(inner) = &self.context {
-            quote! { #inner }
-        } else {
-            quote! { Context }
         }
     }
 

--- a/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
+++ b/juniper-eager-loading-code-gen/src/derive_eager_loading/field_args.rs
@@ -24,6 +24,8 @@ pub struct DeriveArgs {
     error: syn::Path,
     #[darling(default)]
     root_model_field: Option<syn::Ident>,
+    #[darling(default)]
+    context: Option<syn::Path>,
 
     // TODO: Document this new attribute
     #[darling(default)]
@@ -57,6 +59,14 @@ impl DeriveArgs {
             let struct_name = struct_name.to_string().to_snake_case();
             let struct_name = Ident::new(&struct_name, Span::call_site());
             quote! { #struct_name }
+        }
+    }
+
+    pub fn context(&self) -> TokenStream {
+        if let Some(inner) = &self.context {
+            quote! { #inner }
+        } else {
+            quote! { Context }
         }
     }
 

--- a/juniper-eager-loading/src/lib.rs
+++ b/juniper-eager-loading/src/lib.rs
@@ -218,7 +218,8 @@
 //!     // This trait is required for eager loading countries.
 //!     // It defines how to load a list of countries from a list of ids.
 //!     // Notice that `Context` is generic and can be whatever you want.
-//!     // This is this library can be data store agnostic.
+//!     // It will normally be your Juniper context which would contain
+//!     // a database connection.
 //!     impl LoadFrom<i32> for Country {
 //!         type Error = Box<dyn Error>;
 //!         type Context = super::Context;
@@ -245,7 +246,7 @@
 //!     }
 //! }
 //!
-//! // Our Juniper context type.
+//! // Our Juniper context type which contains a database connection.
 //! pub struct Context {
 //!     db: DbConnection,
 //! }
@@ -253,9 +254,9 @@
 //! impl juniper::Context for Context {}
 //!
 //! // Our GraphQL user type.
-//! // `#[derive(EagerLoading)]` takes care of all the heavy lifting.
+//! // `#[derive(EagerLoading)]` takes care of generating all the boilerplate code.
 //! #[derive(Clone, EagerLoading)]
-//! // You need to set the connection and error type.
+//! // You need to set the context and error type.
 //! #[eager_loading(context = "Context", error = "Box<dyn Error>")]
 //! pub struct User {
 //!     // This user model is used to resolve `User.id`
@@ -286,6 +287,7 @@
 //!         trail: &QueryTrail<'_, User, Walked>,
 //!     ) -> FieldResult<Vec<User>> {
 //!         let ctx = executor.context();
+//!
 //!         // Load the model users.
 //!         let user_models = ctx.db.load_all_users();
 //!
@@ -295,7 +297,7 @@
 //!         // Perform the eager loading.
 //!         // `trail` is used to only eager load the fields that are requested. Because
 //!         // we're using `QueryTrail`s from "juniper_from_schema" it would be a compile
-//!         // error if we eager loaded too much.
+//!         // error if we eager loaded associations that aren't requested in the query.
 //!         User::eager_load_all_children_for_each(&mut users, &user_models, ctx, trail)?;
 //!
 //!         Ok(users)
@@ -353,6 +355,9 @@
 //! of how to do that can be found
 //! [here](trait.EagerLoadChildrenOfType.html#manual-implementation).
 //!
+//! If you're interested in seeing full examples without any macros look
+//! [here](https://github.com/davidpdrsn/juniper-eager-loading/tree/master/examples).
+//!
 //! [`EagerLoadChildrenOfType`]: trait.EagerLoadChildrenOfType.html
 //!
 //! ## Attributes
@@ -361,7 +366,7 @@
 //!
 //! | Name | Description | Default | Example |
 //! |---|---|---|---|
-//! | `connection` | The type of connection your app uses. This could be a database connection or a connection to another web service. | N/A | `connection = "diesel::pg::PgConnection"` |
+//! | `context` | The type of your Juniper context. This will often hold your database connection or something else than can be used to load data. | N/A | `context = "Context"` |
 //! | `error` | The type of error eager loading might result in. | N/A | `error = "diesel::result::Error"` |
 //! | `model` | The model type behind your GraphQL struct | `models::{name of struct}` | `model = "crate::db::models::User"` |
 //! | `id` | Which id type does your app use? | `i32` | `id = "UUID"` |

--- a/juniper-eager-loading/src/macros.rs
+++ b/juniper-eager-loading/src/macros.rs
@@ -118,6 +118,30 @@
 /// [`HasMany`]: trait.HasMany.html
 /// [`HasManyThrough`]: trait.HasManyThrough.html
 ///
+/// # `Context::db`
+///
+/// It is required that your context type has a method called `db` which returns a reference to a
+/// Diesel connection that can be passed to `.load(_)`.
+///
+/// Example:
+///
+/// ```rust,ignore
+/// struct Context {
+///     db: PgConnection,
+/// }
+///
+/// impl Context {
+///     fn db(&self) -> &PgConnection {
+///         &self.db
+///     }
+/// }
+///
+/// // Whatever the method returns has to work with Diesel's `load` method
+/// users::table
+///     .filter(users::id.eq(any(user_ids)))
+///     .load::<User>(ctx.db())
+/// ```
+///
 /// # What gets generated
 ///
 /// The two syntaxes generates code like this:

--- a/juniper-eager-loading/src/macros.rs
+++ b/juniper-eager-loading/src/macros.rs
@@ -54,10 +54,21 @@
 ///     company_id: i32,
 /// }
 ///
+/// struct Context {
+///     db: PgConnection,
+/// }
+///
+/// impl Context {
+///     // The macro assumes this method exists
+///     fn db(&self) -> &PgConnection {
+///         &self.db
+///     }
+/// }
+///
 /// impl_load_from_for_diesel_pg! {
 ///     (
 ///         error = diesel::result::Error,
-///         connection = PgConnection,
+///         context = Context,
 ///     ) => {
 ///         i32 -> (users, User),
 ///         i32 -> (companies, Company),
@@ -79,7 +90,7 @@
 /// ```text
 /// (
 ///     error = diesel::result::Error,
-///     connection = PgConnection,
+///     context = Context,
 /// ) => {
 ///     // ...
 /// }
@@ -149,17 +160,24 @@
 /// #     user_id: i32,
 /// #     company_id: i32,
 /// # }
+/// # struct Context { db: PgConnection }
+/// # impl Context {
+/// #     fn db(&self) -> &PgConnection {
+/// #         &self.db
+/// #     }
+/// # }
+///
 /// // i32 -> (users, User),
 /// impl juniper_eager_loading::LoadFrom<i32> for User {
 ///     type Error = diesel::result::Error;
-///     type Connection = PgConnection;
+///     type Context = Context;
 ///
-///     fn load(ids: &[i32], field_args: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+///     fn load(ids: &[i32], field_args: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
 ///         use diesel::pg::expression::dsl::any;
 ///
 ///         users::table
 ///             .filter(users::id.eq(any(ids)))
-///             .load::<User>(db)
+///             .load::<User>(ctx.db())
 ///             .map_err(From::from)
 ///     }
 /// }
@@ -167,15 +185,15 @@
 /// // User.id -> (employments.user_id, Employment),
 /// impl juniper_eager_loading::LoadFrom<User> for Employment {
 ///     type Error = diesel::result::Error;
-///     type Connection = PgConnection;
+///     type Context = Context;
 ///
-///     fn load(froms: &[User], field_args: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+///     fn load(froms: &[User], field_args: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
 ///         use diesel::pg::expression::dsl::any;
 ///
 ///         let from_ids = froms.iter().map(|other| other.id).collect::<Vec<_>>();
 ///         employments::table
 ///             .filter(employments::user_id.eq(any(from_ids)))
-///             .load(db)
+///             .load(ctx.db())
 ///             .map_err(From::from)
 ///     }
 /// }
@@ -243,10 +261,21 @@ macro_rules! impl_load_from_for_diesel_pg {
 ///     company_id: i32,
 /// }
 ///
+/// struct Context {
+///     db: MysqlConnection,
+/// }
+///
+/// impl Context {
+///     // The macro assumes this method exists
+///     fn db(&self) -> &MysqlConnection {
+///         &self.db
+///     }
+/// }
+///
 /// impl_load_from_for_diesel_mysql! {
 ///     (
 ///         error = diesel::result::Error,
-///         connection = MysqlConnection,
+///         context = Context,
 ///     ) => {
 ///         i32 -> (users, User),
 ///         i32 -> (companies, Company),
@@ -323,10 +352,21 @@ macro_rules! impl_load_from_for_diesel_mysql {
 ///     company_id: i32,
 /// }
 ///
+/// struct Context {
+///     db: SqliteConnection,
+/// }
+///
+/// impl Context {
+///     // The macro assumes this method exists
+///     fn db(&self) -> &SqliteConnection {
+///         &self.db
+///     }
+/// }
+///
 /// impl_load_from_for_diesel_sqlite! {
 ///     (
 ///         error = diesel::result::Error,
-///         connection = SqliteConnection,
+///         context = Context,
 ///     ) => {
 ///         i32 -> (users, User),
 ///         i32 -> (companies, Company),

--- a/juniper-eager-loading/tests/compile_pass/impl_load_from_mysql.rs
+++ b/juniper-eager-loading/tests/compile_pass/impl_load_from_mysql.rs
@@ -42,10 +42,20 @@ struct Employment {
     company_id: i32,
 }
 
+struct Context {
+    db: MysqlConnection,
+}
+
+impl Context {
+    fn db(&self) -> &MysqlConnection {
+        &self.db
+    }
+}
+
 impl_load_from_for_diesel_mysql! {
     (
         error = diesel::result::Error,
-        connection = MysqlConnection,
+        context = Context,
     ) => {
         i32 -> (users, User),
         i32 -> (companies, Company),

--- a/juniper-eager-loading/tests/compile_pass/impl_load_from_pg.rs
+++ b/juniper-eager-loading/tests/compile_pass/impl_load_from_pg.rs
@@ -42,10 +42,20 @@ struct Employment {
     company_id: i32,
 }
 
+struct Context {
+    db: PgConnection,
+}
+
+impl Context {
+    fn db(&self) -> &PgConnection {
+        &self.db
+    }
+}
+
 impl_load_from_for_diesel_pg! {
     (
         error = diesel::result::Error,
-        connection = PgConnection,
+        context = Context,
     ) => {
         i32 -> (users, User),
         i32 -> (companies, Company),

--- a/juniper-eager-loading/tests/compile_pass/impl_load_from_sqlite.rs
+++ b/juniper-eager-loading/tests/compile_pass/impl_load_from_sqlite.rs
@@ -42,10 +42,20 @@ struct Employment {
     company_id: i32,
 }
 
+struct Context {
+    db: SqliteConnection,
+}
+
+impl Context {
+    fn db(&self) -> &SqliteConnection {
+        &self.db
+    }
+}
+
 impl_load_from_for_diesel_mysql! {
     (
         error = diesel::result::Error,
-        connection = SqliteConnection,
+        context = Context,
     ) => {
         i32 -> (users, User),
         i32 -> (companies, Company),

--- a/juniper-eager-loading/tests/integration_tests.rs
+++ b/juniper-eager-loading/tests/integration_tests.rs
@@ -142,10 +142,12 @@ mod models {
     impl juniper_eager_loading::LoadFrom<CountryId> for Country {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
         fn load(
             ids: &[CountryId],
             _: &(),
+            _: &Self::Context,
             db: &Self::Connection,
         ) -> Result<Vec<Self>, Self::Error> {
             let countries = db
@@ -162,8 +164,14 @@ mod models {
     impl juniper_eager_loading::LoadFrom<CityId> for City {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
-        fn load(ids: &[CityId], _: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+        fn load(
+            ids: &[CityId],
+            _: &(),
+            _: &Self::Context,
+            db: &Self::Connection,
+        ) -> Result<Vec<Self>, Self::Error> {
             let countries = db
                 .cities
                 .all_values()
@@ -178,8 +186,14 @@ mod models {
     impl juniper_eager_loading::LoadFrom<UserId> for User {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
-        fn load(ids: &[UserId], _: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+        fn load(
+            ids: &[UserId],
+            _: &(),
+            _: &Self::Context,
+            db: &Self::Connection,
+        ) -> Result<Vec<Self>, Self::Error> {
             let models = db
                 .users
                 .all_values()
@@ -194,10 +208,12 @@ mod models {
     impl juniper_eager_loading::LoadFrom<CompanyId> for Company {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
         fn load(
             ids: &[CompanyId],
             _: &(),
+            _: &Self::Context,
             db: &Self::Connection,
         ) -> Result<Vec<Self>, Self::Error> {
             let models = db
@@ -214,10 +230,12 @@ mod models {
     impl juniper_eager_loading::LoadFrom<EmploymentId> for Employment {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
         fn load(
             ids: &[EmploymentId],
             _: &(),
+            _: &Self::Context,
             db: &Self::Connection,
         ) -> Result<Vec<Self>, Self::Error> {
             let models = db
@@ -234,8 +252,14 @@ mod models {
     impl juniper_eager_loading::LoadFrom<IssueId> for Issue {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
-        fn load(ids: &[IssueId], _: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+        fn load(
+            ids: &[IssueId],
+            _: &(),
+            _: &Self::Context,
+            db: &Self::Connection,
+        ) -> Result<Vec<Self>, Self::Error> {
             let models = db
                 .issues
                 .all_values()
@@ -250,10 +274,12 @@ mod models {
     impl juniper_eager_loading::LoadFrom<Country> for City {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
         fn load(
             countries: &[Country],
             _: &(),
+            _: &Self::Context,
             db: &Self::Connection,
         ) -> Result<Vec<Self>, Self::Error> {
             let country_ids = countries
@@ -274,8 +300,14 @@ mod models {
     impl juniper_eager_loading::LoadFrom<User> for Employment {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
-        fn load(users: &[User], _: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+        fn load(
+            users: &[User],
+            _: &(),
+            _: &Self::Context,
+            db: &Self::Connection,
+        ) -> Result<Vec<Self>, Self::Error> {
             let user_ids = users.iter().map(|user| user.id).collect::<Vec<_>>();
             let employments = db
                 .employments
@@ -291,10 +323,12 @@ mod models {
     impl juniper_eager_loading::LoadFrom<Employment> for Company {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
         fn load(
             employments: &[Employment],
             _: &(),
+            _: &Self::Context,
             db: &Self::Connection,
         ) -> Result<Vec<Self>, Self::Error> {
             let company_ids = employments
@@ -317,8 +351,14 @@ mod models {
     impl juniper_eager_loading::LoadFrom<User> for Issue {
         type Error = Box<dyn std::error::Error>;
         type Connection = super::Db;
+        type Context = super::Context;
 
-        fn load(users: &[User], _: &(), db: &Self::Connection) -> Result<Vec<Self>, Self::Error> {
+        fn load(
+            users: &[User],
+            _: &(),
+            _: &Self::Context,
+            db: &Self::Connection,
+        ) -> Result<Vec<Self>, Self::Error> {
             let user_ids = users.iter().map(|user| Some(user.id)).collect::<Vec<_>>();
             let issues = db
                 .issues
@@ -356,7 +396,8 @@ impl QueryFields for Query {
         trail: &QueryTrail<'a, User, Walked>,
         id: i32,
     ) -> FieldResult<User> {
-        let db = &executor.context().db;
+        let context = &executor.context();
+        let db = &context.db;
 
         let user_model = db
             .users
@@ -364,7 +405,7 @@ impl QueryFields for Query {
             .ok_or("User not found")?
             .clone();
         let user = User::new_from_model(&user_model);
-        let user = User::eager_load_all_children(user, &[user_model], db, trail)?;
+        let user = User::eager_load_all_children(user, &[user_model], db, trail, context)?;
         Ok(user)
     }
 
@@ -373,7 +414,8 @@ impl QueryFields for Query {
         executor: &Executor<'a, Context>,
         trail: &QueryTrail<'a, User, Walked>,
     ) -> FieldResult<Vec<User>> {
-        let db = &executor.context().db;
+        let context = &executor.context();
+        let db = &context.db;
 
         let mut user_models = db
             .users
@@ -384,7 +426,7 @@ impl QueryFields for Query {
         user_models.sort_by_key(|user| user.id);
 
         let mut users = User::from_db_models(&user_models);
-        User::eager_load_all_children_for_each(&mut users, &user_models, db, trail)?;
+        User::eager_load_all_children_for_each(&mut users, &user_models, db, trail, context)?;
 
         Ok(users)
     }
@@ -403,6 +445,7 @@ impl MutationFields for Mutation {
 #[eager_loading(
     connection = "Db",
     error = "Box<dyn std::error::Error>",
+    context = "Context",
     // model = "models::User",
     // id = "i32",
     // root_model_field = "user"

--- a/juniper-eager-loading/tests/integration_tests.rs
+++ b/juniper-eager-loading/tests/integration_tests.rs
@@ -127,7 +127,7 @@ mod models {
     }
 
     impl Employment {
-        pub fn primary(&self, _: &super::Db) -> bool {
+        pub fn primary(&self, _: &super::Context) -> bool {
             self.primary
         }
     }
@@ -141,16 +141,11 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<CountryId> for Country {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            ids: &[CountryId],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
-            let countries = db
+        fn load(ids: &[CountryId], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
+            let countries = ctx
+                .db
                 .countries
                 .all_values()
                 .into_iter()
@@ -163,16 +158,11 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<CityId> for City {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            ids: &[CityId],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
-            let countries = db
+        fn load(ids: &[CityId], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
+            let countries = ctx
+                .db
                 .cities
                 .all_values()
                 .into_iter()
@@ -185,16 +175,11 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<UserId> for User {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            ids: &[UserId],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
-            let models = db
+        fn load(ids: &[UserId], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
+            let models = ctx
+                .db
                 .users
                 .all_values()
                 .into_iter()
@@ -207,16 +192,11 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<CompanyId> for Company {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            ids: &[CompanyId],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
-            let models = db
+        fn load(ids: &[CompanyId], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
+            let models = ctx
+                .db
                 .companies
                 .all_values()
                 .into_iter()
@@ -229,16 +209,15 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<EmploymentId> for Employment {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
         fn load(
             ids: &[EmploymentId],
             _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
+            ctx: &Self::Context,
         ) -> Result<Vec<Self>, Self::Error> {
-            let models = db
+            let models = ctx
+                .db
                 .employments
                 .all_values()
                 .into_iter()
@@ -251,16 +230,11 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<IssueId> for Issue {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            ids: &[IssueId],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
-            let models = db
+        fn load(ids: &[IssueId], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
+            let models = ctx
+                .db
                 .issues
                 .all_values()
                 .into_iter()
@@ -273,20 +247,19 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<Country> for City {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
         fn load(
             countries: &[Country],
             _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
+            ctx: &Self::Context,
         ) -> Result<Vec<Self>, Self::Error> {
             let country_ids = countries
                 .iter()
                 .map(|country| country.id)
                 .collect::<Vec<_>>();
-            let mut cities = db
+            let mut cities = ctx
+                .db
                 .cities
                 .all_values()
                 .into_iter()
@@ -299,17 +272,12 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<User> for Employment {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            users: &[User],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
+        fn load(users: &[User], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
             let user_ids = users.iter().map(|user| user.id).collect::<Vec<_>>();
-            let employments = db
+            let employments = ctx
+                .db
                 .employments
                 .all_values()
                 .into_iter()
@@ -322,21 +290,20 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<Employment> for Company {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
         fn load(
             employments: &[Employment],
             _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
+            ctx: &Self::Context,
         ) -> Result<Vec<Self>, Self::Error> {
             let company_ids = employments
                 .iter()
                 .map(|employment| employment.company_id)
                 .collect::<Vec<_>>();
 
-            let employments = db
+            let employments = ctx
+                .db
                 .companies
                 .all_values()
                 .into_iter()
@@ -350,17 +317,12 @@ mod models {
 
     impl juniper_eager_loading::LoadFrom<User> for Issue {
         type Error = Box<dyn std::error::Error>;
-        type Connection = super::Db;
         type Context = super::Context;
 
-        fn load(
-            users: &[User],
-            _: &(),
-            _: &Self::Context,
-            db: &Self::Connection,
-        ) -> Result<Vec<Self>, Self::Error> {
+        fn load(users: &[User], _: &(), ctx: &Self::Context) -> Result<Vec<Self>, Self::Error> {
             let user_ids = users.iter().map(|user| Some(user.id)).collect::<Vec<_>>();
-            let issues = db
+            let issues = ctx
+                .db
                 .issues
                 .all_values()
                 .into_iter()
@@ -396,16 +358,16 @@ impl QueryFields for Query {
         trail: &QueryTrail<'a, User, Walked>,
         id: i32,
     ) -> FieldResult<User> {
-        let context = &executor.context();
-        let db = &context.db;
+        let ctx = executor.context();
 
-        let user_model = db
+        let user_model = ctx
+            .db
             .users
             .get(&UserId::from(id))
             .ok_or("User not found")?
             .clone();
         let user = User::new_from_model(&user_model);
-        let user = User::eager_load_all_children(user, &[user_model], db, trail, context)?;
+        let user = User::eager_load_all_children(user, &[user_model], ctx, trail)?;
         Ok(user)
     }
 
@@ -414,10 +376,10 @@ impl QueryFields for Query {
         executor: &Executor<'a, Context>,
         trail: &QueryTrail<'a, User, Walked>,
     ) -> FieldResult<Vec<User>> {
-        let context = &executor.context();
-        let db = &context.db;
+        let ctx = executor.context();
 
-        let mut user_models = db
+        let mut user_models = ctx
+            .db
             .users
             .all_values()
             .into_iter()
@@ -426,7 +388,7 @@ impl QueryFields for Query {
         user_models.sort_by_key(|user| user.id);
 
         let mut users = User::from_db_models(&user_models);
-        User::eager_load_all_children_for_each(&mut users, &user_models, db, trail, context)?;
+        User::eager_load_all_children_for_each(&mut users, &user_models, ctx, trail)?;
 
         Ok(users)
     }
@@ -443,7 +405,6 @@ impl MutationFields for Mutation {
 // The default values are commented out
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, EagerLoading)]
 #[eager_loading(
-    connection = "Db",
     error = "Box<dyn std::error::Error>",
     context = "Context",
     // model = "models::User",
@@ -583,7 +544,7 @@ impl UserFields for User {
 #[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EagerLoading)]
 #[eager_loading(
     model = "models::Country",
-    connection = "Db",
+    context = "Context",
     id = "i32",
     error = "Box<dyn std::error::Error>",
     root_model_field = "country"
@@ -616,7 +577,7 @@ impl CountryFields for Country {
 #[eager_loading(
     model = "models::City",
     id = "i32",
-    connection = "Db",
+    context = "Context",
     error = "Box<dyn std::error::Error>",
     root_model_field = "city"
 )]
@@ -641,7 +602,7 @@ impl CityFields for City {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EagerLoading)]
-#[eager_loading(connection = "Db", error = "Box<dyn std::error::Error>")]
+#[eager_loading(context = "Context", error = "Box<dyn std::error::Error>")]
 pub struct Company {
     company: models::Company,
 }
@@ -657,7 +618,7 @@ impl CompanyFields for Company {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EagerLoading)]
-#[eager_loading(connection = "Db", error = "Box<dyn std::error::Error>")]
+#[eager_loading(context = "Context", error = "Box<dyn std::error::Error>")]
 pub struct Employment {
     employment: models::Employment,
     #[has_one(default)]
@@ -689,7 +650,7 @@ impl EmploymentFields for Employment {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EagerLoading)]
-#[eager_loading(connection = "Db", error = "Box<dyn std::error::Error>")]
+#[eager_loading(context = "Context", error = "Box<dyn std::error::Error>")]
 pub struct Issue {
     issue: models::Issue,
     #[option_has_one(root_model_field = "user")]


### PR DESCRIPTION
Fixes https://github.com/davidpdrsn/juniper-eager-loading/issues/32

## TODO

- [x] Update tests
- [x] Write docs and make sure all old docs still make sense now that `GraphqlNodeForModel::Connection` is called `Context`.
- [x] Update changelog. This is a breaking change.
- [x] Document the need for defining `Context::database_connection` for diesel macro