### PR TITLE
Fixes #36 : Remove 'experimental' phrase from docs.

### DIFF
--- a/juniper-eager-loading/README.md
+++ b/juniper-eager-loading/README.md
@@ -1,6 +1,5 @@
 # [juniper-eager-loading](https://crates.io/crates/juniper-eager-loading)
 
-🚨 **This library is still experimental and everything is subject to change** 🚨
 
 This is a library for avoiding N+1 query bugs designed to work with
 [Juniper][] and [juniper-from-schema][].

--- a/juniper-eager-loading/src/lib.rs
+++ b/juniper-eager-loading/src/lib.rs
@@ -1,8 +1,6 @@
 //! juniper-eager-loading is a library for avoiding N+1 query bugs designed to work with
 //! [Juniper][] and [juniper-from-schema][].
 //!
-//! <center>🚨 **This library is still experimental and everything is subject to change** 🚨</center>
-//!
 //! It is designed to make the most common assocation setups easy to handle and while being
 //! flexible and allowing you to customize things as needed. It is also 100% data store agnostic.
 //! So regardless if your API is backed by an SQL database or another API you can still use this


### PR DESCRIPTION
Removed the `**This library is still experimental and everything is subject to change** ` phrase from 2 prominent doc files.