### PR TITLE
Use primary_key function instead of id column

### DIFF
--- a/juniper-eager-loading-code-gen/src/impl_load_from_for_diesel.rs
+++ b/juniper-eager-loading-code-gen/src/impl_load_from_for_diesel.rs
@@ -162,12 +162,12 @@ impl HasOne {
         let filter = match backend {
             Backend::Pg => {
                 quote! {
-                    #table::id.eq(diesel::pg::expression::dsl::any(ids))
+                    #table::table.primary_key().eq(diesel::pg::expression::dsl::any(ids))
                 }
             }
             Backend::Mysql | Backend::Sqlite => {
                 quote! {
-                    #table::id.eq_any(ids)
+                    #table::table.primary_key().eq_any(ids)
                 }
             }
         };


### PR DESCRIPTION
Diesel generated a `primary_key` function for all tables created with table macro. The trait can be found [here](http://docs.diesel.rs/diesel/query_source/trait.Table.html#tymethod.primary_key).

By using this function instead of the `id` column, the primary key column can have any arbitrary name. As this allows for more freely defined tables, I think this would be a simple but good improvement.